### PR TITLE
Fix incorrect usage of environment.processor count when collect metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.18 (26-06-2023):
+
+Fixed incorrect usage of Environment.ProcessorCount value (use host cores instead).
+
+[Backward compability was broken in .net6](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/environment-processorcount-on-windows)
+
 ## 0.3.17 (28-09-2022):
 
 Fixed unlimited cgroup limits.

--- a/Vostok.Metrics.System/Host/NativeHostMetricsCollector_Windows.cs
+++ b/Vostok.Metrics.System/Host/NativeHostMetricsCollector_Windows.cs
@@ -200,7 +200,7 @@ namespace Vostok.Metrics.System.Host
             }
         }
 
-        private static int? GetProcessorCount()
+        internal static int? GetProcessorCount()
         {
             {
                 try

--- a/Vostok.Metrics.System/Process/CurrentProcessMetrics.cs
+++ b/Vostok.Metrics.System/Process/CurrentProcessMetrics.cs
@@ -8,7 +8,7 @@ namespace Vostok.Metrics.System.Process
     {
         /// <summary>
         /// <para>Number of CPU cores utilized by current process.</para>
-        /// <para>This metric has a value between 0 and <see cref="Environment.ProcessorCount"/>.</para>
+        /// <para>This metric has a value between 0 and the total number of logical processors on the machine.</para>
         /// <para>This metric is an average value between two observation moments (current and previous).</para>
         /// </summary>
         public double CpuUtilizedCores { get; set; }

--- a/Vostok.Metrics.System/Process/NativeMetricsCollector_Windows.cs
+++ b/Vostok.Metrics.System/Process/NativeMetricsCollector_Windows.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using Vostok.Metrics.System.Helpers;
+using Vostok.Metrics.System.Host;
 
 // ReSharper disable FieldCanBeMadeReadOnly.Local
 // ReSharper disable MemberCanBePrivate.Local
@@ -84,7 +85,10 @@ namespace Vostok.Metrics.System.Process
                 var systemTime = systemKernel.ToUInt64() + systemUser.ToUInt64();
                 var processTime = processKernel.ToUInt64() + processUser.ToUInt64();
 
-                cpuCollector.Collect(metrics, systemTime, processTime);
+                // note: Environment.ProcessorCount from NET6+ respects process affinity and the job object's hard limit on CPU utilization
+                // https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/environment-processorcount-on-windows
+                // so we should get total number of system cores from NativeHostMetricsCollector_Windows instead
+                cpuCollector.Collect(metrics, systemTime, processTime, NativeHostMetricsCollector_Windows.GetProcessorCount());
             }
             catch (Exception error)
             {


### PR DESCRIPTION
https://github.com/vostok/metrics.system/issues/38

Environment.ProcessorCount from NET6+ respects process affinity and the job object's hard limit on CPU utilization
https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/environment-processorcount-on-windows

so we should get total number of system cores from NativeHostMetricsCollector_Windows instead